### PR TITLE
Fix build with correct RISCV_ACPI_SPEC file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 ASCIIDOCTOR = asciidoctor
 DITAA = ditaa
-RISCV_ACPI_SPEC = riscv-acpi-platform-spec
+RISCV_ACPI_SPEC = riscv-acpi-platform-req
 PANDOC = pandoc
 
 # Build the platform spec in several formats


### PR DESCRIPTION
The asciidoc file is riscv-acpi-platform-req.adoc. Fix the build
by using the correct file name.

Signed-off-by: Aaron Durbin <adurbin@rivosinc.com>
